### PR TITLE
Updates to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ with defining your own Data Product Definitions.
 
 # Getting started
 
-Press `Use template` to create a new repo from this template and define your data
+Press `Use this template` to create a new repo from this template and define your data
 products there.
 
-## Adding new Data Product Definition
+## Adding new Data Product Definitions
 
 There are two ways of contribution:
 
@@ -29,9 +29,8 @@ There are two ways of contribution:
 
 2. **Submit definition as python file**
 
-   If you're familiar with python and
-   [pydantic](https://github.com/samuelcolvin/pydantic) library, you may find it easier
-   to create the definition as a set of pydantic models.
+   If you're familiar with python and [pydantic](https://pydantic-docs.helpmanual.io/)
+   library, you may find it easier to create the definition as a set of pydantic models.
 
    For example, to add a definition for `Foo/Bar`:
 
@@ -94,7 +93,8 @@ DataProductDefinition is a structure consisting of:
 
 - `description`
 
-  Data product description, used in top of OpenAPI spec
+  Data product description, used in top of OpenAPI spec (defaults to the summary if not
+  provided)
 
 - `request`
 
@@ -110,14 +110,15 @@ DataProductDefinition is a structure consisting of:
 
 - `route_description`
 
-  Description for the POST route
+  Description for the POST route (defaults to the summary if not provided)
 
-- `generic_description`
+- `requires_authorization`
 
-  You may omit providing `summary`, `description`, `route_summary` and
-  `route_description` if you define this field. Others will be generated automatically
-  based on it. Use something brief and meaningful, like "Company Recommendations" or
-  "Cargo receipt".
+  Marks the Authorization header as required
+
+- `requires_consent`
+
+  Marks the X-Consent-Token header as required
 
 ### Example
 


### PR DESCRIPTION
- Correct name of button in GitHub UI (it's `Use this template`, not `Use template`).
- Link to pydantic documentation rather than (outdated link) to GitHub project.
- Remove description for `generic_description` that was removed from the data product definition tooling and add details about corresponding changes to fields that default to the summary instead.
- Add details about `requires_authorization` and  `requires_consent`
- `Adding new Data Product Definition` -> `Adding new Data Product Definitions`