### PR TITLE
Update tooling and README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/ioxio-dataspace/data-product-definition-tooling
-    rev: 0.0.9
+    rev: 0.0.12
     hooks:
       - id: data-product-definition-converter
         # TODO: convert only the file that was changed
@@ -43,12 +43,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/ioxiocom/openapi-to-fastapi
-    rev: 0.5.0
+    rev: 0.10.0
     hooks:
       - id: openapi-validator
         files: ".*?DataProducts/.*?json$"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ structure:
 ```python
 from pydantic import Field
 
-from converter import CamelCaseModel, DataProductDefinition
+from converter import CamelCaseModel, DataProductDefinition, ErrorResponse
 
 
 class Request(CamelCaseModel):
@@ -42,12 +42,23 @@ class Response(CamelCaseModel):
     ...
 
 
+@ErrorResponse(description="...")
+class Error418(CamelCaseModel):
+    ...
+
+
 DEFINITION = DataProductDefinition(
     description="...",
     request=Request,
     response=Response,
     route_description="...",
     summary="...",
+    requires_authorization=False,
+    requires_consent=False,
+    error_responses={
+        418: Error418,
+    },
+    deprecated=False,
 )
 
 ```
@@ -94,6 +105,15 @@ DataProductDefinition is a structure consisting of:
 - `requires_consent`
 
   Marks the X-Consent-Token header as required
+
+- `error_responses`
+
+  A mapping from HTTP error status codes to pydantic models, wrapped in the
+  `ErrorResponse` decorator, describing expected error responses from the data source
+
+- `deprecated`
+
+  Marks the route as deprecated
 
 ### Example
 


### PR DESCRIPTION
- Update the `data-product-definition-tooling` to a new version that supports `ErrorResponse`s and marking routes as deprecated and the README to reflect these new features.
- Update the `openapi-to-fastapi` and `black` to most recent versions.