### PR TITLE
Update pre-commit hooks to fix issues on Python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -19,11 +19,11 @@ repos:
         args: ["--fix=crlf"]
         files: \.bat$
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.2
+    rev: v0.9.0.6
     hooks:
       - id: shellcheck
   - repo: https://github.com/ioxio-dataspace/ioxio-data-product-definition-tooling
-    rev: 0.4.0
+    rev: 0.5.0
     hooks:
       - id: data-product-definition-converter
         # TODO: convert only the file that was changed
@@ -48,13 +48,13 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/ioxiocom/openapi-to-fastapi
-    rev: 0.13.0
+    rev: 0.14.0
     hooks:
       - id: openapi-validator
         files: ".*?DataProducts/.*?json$"
         args: ["--path", "./DataProducts"]
   - repo: https://github.com/ioxio-dataspace/ioxio-data-product-definition-tooling
-    rev: 0.4.0
+    rev: 0.5.0
     hooks:
       - id: data-product-definition-validator
         files: ".*?DataProducts/.*?json$"


### PR DESCRIPTION
Updates especially the pre-commit hook for shellcheck-py to work on Pyhton 3.12. Also other minor updates to other pre-commit hooks.